### PR TITLE
Feature: complete test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ Change categories are:
 ### Removed
 ### Security
 
+## [1.0.0](https://github.com/saibotsivad/mdast-util-noddity/compare/v0.0.2...v1.0.0) - 2022-07-26
+### Added
+- Full test coverage, with support for templates and markdown inside link text. With full tests, I'm pretty happy with where things are, so I'll move it out of beta version.
+### Changed
+- BREAKING CHANGE: In the process of adding full test coverage for all Noddity syntax, the exact tree structure changed slightly.
+
 ## [0.0.2](https://github.com/saibotsivad/mdast-util-noddity/compare/v0.0.0...v0.0.2) - 2022-07-20
 ### Changed
 - Property name of the mutator function.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ This corresponds to the Noddity link syntax, and has these properties:
 
 * `type = "noddityLink"` - The type.
 * `file: String` - The file reference part of the link.
-* `text?: String` - *(Optional)* The text part of the link, if present.
+* `children?: Array<MdastTree>` - *(Optional)* If there is a text part of the link, it will be parsed as `mdast` itself, so child elements will be a deeper `mdast` tree.
 
 #### `noddityTemplate`
 

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ export const micromarkFromNoddity = () => {
 
 	function tokenizeClosingLinkFence(effects, ok, nok) {
 		let sizeClose = 0
+		// eslint-disable-next-line @typescript-eslint/no-this-alias
 		let self = this
 		return closeFence
 		function closeFence(code) {
@@ -50,6 +51,7 @@ export const micromarkFromNoddity = () => {
 		let sizeOpen = 0
 		let marker
 		let hasBeenPiped
+		// eslint-disable-next-line @typescript-eslint/no-this-alias
 		let self = this
 
 		return start

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,10 @@
-import { markdownLineEnding } from 'micromark-util-character'
-
-import { types } from 'micromark-util-symbol/types.js'
-// import { codes } from 'micromark-util-symbol/codes.js'
-// console.log(codes)
-
 export { noddityMdastMutator } from './mutator.js'
 
 const CHARS = {
 	CR: -5,
 	LF: -4,
 	CRLF: -3,
+	HORIZONTAL_TAB: -2,
 	SQUARE_BRACE_LEFT: 91,
 	SQUARE_BRACE_RIGHT: 93,
 	PIPE: 124,
@@ -17,6 +12,8 @@ const CHARS = {
 }
 
 const LINK_FENCE_CHAR_LENGTH = 2
+
+const markdownLineEnding = code => code !== null && code < CHARS.HORIZONTAL_TAB
 
 export const micromarkFromNoddity = () => {
 
@@ -95,7 +92,7 @@ export const micromarkFromNoddity = () => {
 			if (markdownLineEnding(code) || code === null) { // newlines not allowed in links
 				return nok(code)
 			} else if (code !== CHARS.SQUARE_BRACE_RIGHT && previousType === 'noddityLinkDelimiter') {
-				effects.enter('noddityLinkText', { contentType: types.content })
+				effects.enter('noddityLinkText', { contentType: 'content' })
 				effects.consume(code)
 				return linkUrlOpen
 			} else if (code === CHARS.PIPE && !hasBeenPiped) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,9 @@
 import { markdownLineEnding } from 'micromark-util-character'
 
+import { types } from 'micromark-util-symbol/types.js'
+// import { codes } from 'micromark-util-symbol/codes.js'
+// console.log(codes)
+
 export { noddityMdastMutator } from './mutator.js'
 
 const CHARS = {
@@ -15,10 +19,41 @@ const CHARS = {
 const LINK_FENCE_CHAR_LENGTH = 2
 
 export const micromarkFromNoddity = () => {
+
+	function tokenizeClosingLinkFence(effects, ok, nok) {
+		let sizeClose = 0
+		let self = this
+		return closeFence
+		function closeFence(code) {
+			if (code === CHARS.SQUARE_BRACE_RIGHT && !sizeClose) {
+				const previousType = self.events[self.events.length - 1][1].type
+				if (previousType !== 'noddityLinkDelimiter') effects.exit(
+					// could be closing a link, or could be closing the text
+					previousType,
+				)
+				effects.enter('noddityLinkFence')
+				effects.consume(code)
+				sizeClose++
+				return closeFence
+			} else if (code === CHARS.SQUARE_BRACE_RIGHT) {
+				sizeClose++
+				effects.consume(code)
+				if (sizeClose === LINK_FENCE_CHAR_LENGTH) {
+					effects.exit('noddityLinkFence')
+					return ok(code)
+				} else {
+					return nok(code)
+				}
+			}
+			return nok(code)
+		}
+	}
+
 	function noddityLinkTokenize(effects, ok, nok) {
 		let sizeOpen = 0
-		let sizeClose = 0
 		let marker
+		let hasBeenPiped
+		let self = this
 
 		return start
 
@@ -39,45 +74,76 @@ export const micromarkFromNoddity = () => {
 				return nok(code)
 			} else {
 				effects.exit('noddityLinkFence')
-				effects.enter('noddityLinkText')
+				effects.enter('noddityLinkUrl')
 				effects.consume(code)
-				return linkOpen
+				return linkUrlOpen
 			}
 		}
 
-		function linkOpen(code) {
-			if (markdownLineEnding(code)) { // newlines not allowed in links
-				return nok(code)
-			} else if (code === CHARS.SQUARE_BRACE_RIGHT) { // TODO right square brace not allowed in filename?
-				effects.exit('noddityLinkText')
-				effects.enter('noddityLinkFence')
-				marker = code
-				return linkClose(code)
-			} else {
-				effects.consume(code)
-				return linkOpen
-			}
+		function wasCorrectFence(code) {
+			effects.exit('noddityLink')
+			return ok(code)
 		}
 
-		function linkClose(code) {
-			if (code === marker) {
-				effects.consume(code)
-				sizeClose++
-				return linkClose
-			}
+		function wasColonInText(code) {
+			effects.consume(code)
+			return linkUrlOpen
+		}
 
-			effects.exit('noddityLinkFence')
-			if (sizeClose < LINK_FENCE_CHAR_LENGTH) {
+		function linkUrlOpen(code) {
+			const previousType = self.events[self.events.length - 1]?.[1]?.type
+			if (markdownLineEnding(code) || code === null) { // newlines not allowed in links
 				return nok(code)
+			} else if (code !== CHARS.SQUARE_BRACE_RIGHT && previousType === 'noddityLinkDelimiter') {
+				effects.enter('noddityLinkText', { contentType: types.content })
+				effects.consume(code)
+				return linkUrlOpen
+			} else if (code === CHARS.PIPE && !hasBeenPiped) {
+				hasBeenPiped = true
+				effects.exit('noddityLinkUrl')
+				effects.enter('noddityLinkDelimiter')
+				effects.consume(code)
+				effects.exit('noddityLinkDelimiter')
+				return linkUrlOpen
+			} else if (code === CHARS.SQUARE_BRACE_RIGHT) {
+				return effects.attempt(
+					{ tokenize: tokenizeClosingLinkFence, partial: true },
+					wasCorrectFence,
+					wasColonInText,
+				)
 			} else {
-				effects.exit('noddityLink')
-				return ok(code)
+				effects.consume(code)
+				return linkUrlOpen
 			}
 		}
 	}
+
+	function tokenizeClosingTemplateFence(effects, ok, nok) {
+		let sizeClose = 0
+		return closeFence
+		function closeFence(code) {
+			if (code === CHARS.COLON && !sizeClose) {
+				effects.exit('noddityTemplateText')
+				effects.enter('noddityTemplateFence')
+				effects.consume(code)
+				sizeClose++
+				return closeFence
+			} else if (code === CHARS.COLON) {
+				sizeClose++
+				effects.consume(code)
+				if (sizeClose === LINK_FENCE_CHAR_LENGTH) {
+					effects.exit('noddityTemplateFence')
+					return ok(code)
+				} else {
+					return nok(code)
+				}
+			}
+			return nok(code)
+		}
+	}
+
 	function noddityTemplateTokenize(effects, ok, nok) {
 		let sizeOpen = 0
-		let sizeClose = 0
 		let marker
 
 		return start
@@ -95,7 +161,7 @@ export const micromarkFromNoddity = () => {
 				sizeOpen++
 				return templateSequenceOpen
 			}
-			if (sizeOpen < LINK_FENCE_CHAR_LENGTH) {
+			if (sizeOpen !== LINK_FENCE_CHAR_LENGTH) {
 				return nok(code)
 			} else {
 				effects.exit('noddityTemplateFence')
@@ -106,35 +172,27 @@ export const micromarkFromNoddity = () => {
 		}
 
 		function templateOpen(code) {
-			if (markdownLineEnding(code)) { // newlines not allowed in templates
+			if (markdownLineEnding(code) || code === null) { // newlines not allowed in templates
 				return nok(code)
-			} else if (code === CHARS.COLON) { // TODO colon not allowed in filename?
-				effects.exit('noddityTemplateText')
-				effects.enter('noddityTemplateFence')
-				marker = code
-				return templateClose(code)
+			} else if (code === CHARS.COLON) {
+				return effects.attempt(
+					{ tokenize: tokenizeClosingTemplateFence, partial: true },
+					function wasCorrectFence(code) {
+						effects.exit('noddityTemplate')
+						return ok(code)
+					},
+					function wasColonInText(code) {
+						effects.consume(code)
+						return templateOpen
+					},
+				)
 			} else {
 				effects.consume(code)
 				return templateOpen
 			}
 		}
-
-		function templateClose(code) {
-			if (code === marker) {
-				effects.consume(code)
-				sizeClose++
-				return templateClose
-			}
-
-			effects.exit('noddityTemplateFence')
-			if (sizeClose < LINK_FENCE_CHAR_LENGTH) {
-				return nok(code)
-			} else {
-				effects.exit('noddityTemplate')
-				return ok(code)
-			}
-		}
 	}
+
 	return {
 		text: {
 			[CHARS.SQUARE_BRACE_LEFT]: {
@@ -152,28 +210,35 @@ export const micromarkFromNoddity = () => {
 export const mdastFromNoddity = () => {
 	return {
 		enter: {
-			noddityLinkText: enterNoddityLinkUrl,
+			noddityLink: enterNoddityLink,
+			noddityLinkUrl: enterNoddityLinkUrl,
 			noddityTemplateText: enterNoddityTemplateText,
 		},
 		exit: {
-			noddityLinkText: exitNoddityLinkUrl,
+			noddityLink: exitNoddityLink,
+			noddityLinkUrl: exitNoddityLinkUrl,
 			noddityTemplateText: exitNoddityTemplateText,
 		},
 	}
+	function enterNoddityLink(token) {
+		this.enter({ type: 'noddityLink', children: [] }, token)
+	}
+	function exitNoddityLink(token) {
+		const node = this.exit(token)
+		if (node.children[0]?.type === 'noddityLinkUrl') {
+			const urlNode = node.children.shift()
+			node.file = urlNode.file
+		}
+		if (node.children.length === 1 && node.children[0].type === 'paragraph' && node.children[0].children) {
+			node.children = node.children[0].children
+		}
+		if (!node.children.length) delete node.children
+	}
 	function enterNoddityLinkUrl(token) {
-		this.enter({ type: 'noddityLink' }, token)
+		this.enter({ type: 'noddityLinkUrl', file: this.sliceSerialize(token) }, token)
 	}
 	function exitNoddityLinkUrl(token) {
-		const node = this.exit(token)
-		let fileString = this.sliceSerialize(token)
-		const firstPipeIndex = fileString.indexOf('|')
-		let textString
-		if (firstPipeIndex > 0) {
-			textString = fileString.slice(firstPipeIndex + 1)
-			fileString = fileString.slice(0, firstPipeIndex)
-		}
-		node.file = fileString
-		if (textString) node.text = textString
+		this.exit(token)
 	}
 	function enterNoddityTemplateText(token) {
 		this.enter({ type: 'noddityTemplate', children: [] }, token)

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -8,7 +8,7 @@ const recurseRemovePosition = obj => {
 	if (obj?.position) delete obj.position
 }
 
-test('basic link parsing', () => {
+test('basic link parsing with text', () => {
 	const tree = fromMarkdown('Links [[file.md|internal]] are neat', {
 		extensions: [ micromarkFromNoddity() ],
 		mdastExtensions: [ mdastFromNoddity() ],
@@ -29,7 +29,12 @@ test('basic link parsing', () => {
 						{
 							type: 'noddityLink',
 							file: 'file.md',
-							text: 'internal',
+							children: [
+								{
+									type: 'text',
+									value: 'internal',
+								},
+							],
 						},
 						{
 							type: 'text',
@@ -75,7 +80,220 @@ test('basic link parsing without text', () => {
 	)
 })
 
-test('basic link parsing', () => {
+test('link parsing where a square bracket is in the text part', () => {
+	const tree = fromMarkdown('Links [[file.md|has [some] note]] are neat', {
+		extensions: [ micromarkFromNoddity() ],
+		mdastExtensions: [ mdastFromNoddity() ],
+	})
+	recurseRemovePosition(tree)
+	assert.equal(
+		tree,
+		{
+			type: 'root',
+			children: [
+				{
+					type: 'paragraph',
+					children: [
+						{
+							type: 'text',
+							value: 'Links ',
+						},
+						{
+							type: 'noddityLink',
+							file: 'file.md',
+							children: [
+								{
+									type: 'text',
+									value: 'has [some] note',
+								},
+							],
+						},
+						{
+							type: 'text',
+							value: ' are neat',
+						},
+					],
+				},
+			],
+		},
+	)
+})
+
+test('link parsing where a pipe is in the text part', () => {
+	const tree = fromMarkdown('Links [[file.md|has | pipe]] are neat', {
+		extensions: [ micromarkFromNoddity() ],
+		mdastExtensions: [ mdastFromNoddity() ],
+	})
+	recurseRemovePosition(tree)
+	assert.equal(
+		tree,
+		{
+			type: 'root',
+			children: [
+				{
+					type: 'paragraph',
+					children: [
+						{
+							type: 'text',
+							value: 'Links ',
+						},
+						{
+							type: 'noddityLink',
+							file: 'file.md',
+							children: [
+								{
+									type: 'text',
+									value: 'has | pipe',
+								},
+							],
+						},
+						{
+							type: 'text',
+							value: ' are neat',
+						},
+					],
+				},
+			],
+		},
+	)
+})
+
+test('link parsing with markdown in the text part', () => {
+	const tree = fromMarkdown('Links [[file.md|has *some* note]] are neat', {
+		extensions: [ micromarkFromNoddity() ],
+		mdastExtensions: [ mdastFromNoddity() ],
+	})
+	recurseRemovePosition(tree)
+	assert.equal(
+		tree,
+		{
+			type: 'root',
+			children: [
+				{
+					type: 'paragraph',
+					children: [
+						{
+							type: 'text',
+							value: 'Links ',
+						},
+						{
+							type: 'noddityLink',
+							children: [
+								{
+									type: 'text',
+									value: 'has ',
+								},
+								{
+									type: 'emphasis',
+									children: [
+										{
+											type: 'text',
+											value: 'some',
+										},
+									],
+								},
+								{
+									type: 'text',
+									value: ' note',
+								},
+							],
+							file: 'file.md',
+						},
+						{
+							type: 'text',
+							value: ' are neat',
+						},
+					],
+				},
+			],
+		},
+	)
+})
+
+test('link with newline is not valid', () => {
+	const tree = fromMarkdown('Links [[file.md|has\na note]] are neat', {
+		extensions: [ micromarkFromNoddity() ],
+		mdastExtensions: [ mdastFromNoddity() ],
+	})
+	recurseRemovePosition(tree)
+	assert.equal(
+		tree,
+		{
+			type: 'root',
+			children: [
+				{
+					type: 'paragraph',
+					children: [
+						{
+							type: 'text',
+							value: 'Links [[file.md|has\na note]] are neat',
+						},
+					],
+				},
+			],
+		},
+	)
+})
+
+test('link that does not end is not valid', () => {
+	const tree = fromMarkdown('Links [[file.md|has', {
+		extensions: [ micromarkFromNoddity() ],
+		mdastExtensions: [ mdastFromNoddity() ],
+	})
+	recurseRemovePosition(tree)
+	assert.equal(
+		tree,
+		{
+			type: 'root',
+			children: [
+				{
+					type: 'paragraph',
+					children: [
+						{
+							type: 'text',
+							value: 'Links [[file.md|has',
+						},
+					],
+				},
+			],
+		},
+	)
+})
+
+test('link with another square bracket ending after means first one was link end', () => {
+	const tree = fromMarkdown('Links [[file.md|]]text]] are neat', {
+		extensions: [ micromarkFromNoddity() ],
+		mdastExtensions: [ mdastFromNoddity() ],
+	})
+	recurseRemovePosition(tree)
+	assert.equal(
+		tree,
+		{
+			type: 'root',
+			children: [
+				{
+					type: 'paragraph',
+					children: [
+						{
+							type: 'text',
+							value: 'Links ',
+						},
+						{
+							type: 'noddityLink',
+							file: 'file.md',
+						},
+						{
+							type: 'text',
+							value: 'text]] are neat',
+						},
+					],
+				},
+			],
+		},
+	)
+})
+
+test('basic template parsing', () => {
 	const tree = fromMarkdown('Templates ::file.md|cars|wheels=2:: are neat', {
 		extensions: [ micromarkFromNoddity() ],
 		mdastExtensions: [ mdastFromNoddity() ],
@@ -111,6 +329,290 @@ test('basic link parsing', () => {
 						{
 							type: 'text',
 							value: ' are neat',
+						},
+					],
+				},
+			],
+		},
+	)
+})
+
+test('template parsing as paragraph', () => {
+	const tree = fromMarkdown('words1\n\n::file.md|cars|wheels=2::\n\nwords2', {
+		extensions: [ micromarkFromNoddity() ],
+		mdastExtensions: [ mdastFromNoddity() ],
+	})
+	recurseRemovePosition(tree)
+	assert.equal(
+		tree,
+		{
+			type: 'root',
+			children: [
+				{
+					type: 'paragraph',
+					children: [
+						{
+							type: 'text',
+							value: 'words1',
+						},
+					],
+				},
+				{
+					type: 'paragraph',
+					children: [
+						{
+							type: 'noddityTemplate',
+							file: 'file.md',
+							children: [
+								{
+									type: 'noddityTemplateVariable',
+									name: 'cars',
+								},
+								{
+									type: 'noddityTemplateVariable',
+									name: 'wheels',
+									value: '2',
+								},
+							],
+						},
+					],
+				},
+				{
+					type: 'paragraph',
+					children: [
+						{
+							type: 'text',
+							value: 'words2',
+						},
+					],
+				},
+			],
+		},
+	)
+})
+
+test('newlines are not supported in templates', () => {
+	const tree = fromMarkdown('word1 ::file.md|\nthings:: word2', {
+		extensions: [ micromarkFromNoddity() ],
+		mdastExtensions: [ mdastFromNoddity() ],
+	})
+	recurseRemovePosition(tree)
+	assert.equal(
+		tree,
+		{
+			type: 'root',
+			children: [
+				{
+					type: 'paragraph',
+					children: [
+						{
+							type: 'text',
+							value: 'word1 ::file.md|\nthings:: word2',
+						},
+					],
+				},
+			],
+		},
+	)
+})
+
+test('end of file in template means not a valid template', () => {
+	const tree = fromMarkdown('word1 ::file.md|', {
+		extensions: [ micromarkFromNoddity() ],
+		mdastExtensions: [ mdastFromNoddity() ],
+	})
+	recurseRemovePosition(tree)
+	assert.equal(
+		tree,
+		{
+			type: 'root',
+			children: [
+				{
+					type: 'paragraph',
+					children: [
+						{
+							type: 'text',
+							value: 'word1 ::file.md|',
+						},
+					],
+				},
+			],
+		},
+	)
+})
+
+test('template parsing where variables portion contain semicolons that are not next to each other', () => {
+	const tree = fromMarkdown('Please read ::book-description.md|My Book: It Has Words:: on the webs.', {
+		extensions: [ micromarkFromNoddity() ],
+		mdastExtensions: [ mdastFromNoddity() ],
+	})
+	recurseRemovePosition(tree)
+	assert.equal(
+		tree,
+		{
+			type: 'root',
+			children: [
+				{
+					type: 'paragraph',
+					children: [
+						{
+							type: 'text',
+							value: 'Please read ',
+						},
+						{
+							type: 'noddityTemplate',
+							children: [
+								{
+									type: 'noddityTemplateVariable',
+									name: 'My Book: It Has Words',
+								},
+							],
+							file: 'book-description.md',
+						},
+						{
+							type: 'text',
+							value: ' on the webs.',
+						},
+					],
+				},
+			],
+		},
+	)
+})
+
+test('template parsing where multiple semicolons means end of template', () => {
+	const tree = fromMarkdown('Please read ::book-description.md|My Book:: It Has Words:: on the webs.', {
+		extensions: [ micromarkFromNoddity() ],
+		mdastExtensions: [ mdastFromNoddity() ],
+	})
+	recurseRemovePosition(tree)
+	assert.equal(
+		tree,
+		{
+			type: 'root',
+			children: [
+				{
+					type: 'paragraph',
+					children: [
+						{
+							type: 'text',
+							value: 'Please read ',
+						},
+						{
+							type: 'noddityTemplate',
+							children: [
+								{
+									type: 'noddityTemplateVariable',
+									name: 'My Book',
+								},
+							],
+							file: 'book-description.md',
+						},
+						{
+							type: 'text',
+							value: ' It Has Words:: on the webs.',
+						},
+					],
+				},
+			],
+		},
+	)
+})
+
+test('template parsing where a template is right after a template and no spaces', () => {
+	const tree = fromMarkdown('word1::file1.md|var1::::file2.md|var2::word2', {
+		extensions: [ micromarkFromNoddity() ],
+		mdastExtensions: [ mdastFromNoddity() ],
+	})
+	recurseRemovePosition(tree)
+	assert.equal(
+		tree,
+		{
+			type: 'root',
+			children: [
+				{
+					type: 'paragraph',
+					children: [
+						{
+							type: 'text',
+							value: 'word1',
+						},
+						{
+							type: 'noddityTemplate',
+							children: [
+								{
+									type: 'noddityTemplateVariable',
+									name: 'var1',
+								},
+							],
+							file: 'file1.md',
+						},
+						{
+							type: 'noddityTemplate',
+							children: [
+								{
+									type: 'noddityTemplateVariable',
+									name: 'var2',
+								},
+							],
+							file: 'file2.md',
+						},
+						{
+							type: 'text',
+							value: 'word2',
+						},
+					],
+				},
+			],
+		},
+	)
+})
+
+test('link with a template', () => {
+	const tree = fromMarkdown('word1 [[file.md|title ::big.md|with:: template]] word2', {
+		extensions: [ micromarkFromNoddity() ],
+		mdastExtensions: [ mdastFromNoddity() ],
+	})
+	recurseRemovePosition(tree)
+	assert.equal(
+		tree,
+		{
+			type: 'root',
+			children: [
+				{
+					type: 'paragraph',
+					children: [
+						{
+							type: 'text',
+							value: 'word1 ',
+						},
+						{
+							type: 'noddityLink',
+							children: [
+								{
+									type: 'text',
+									value: 'title ',
+								},
+								{
+									type: 'noddityTemplate',
+									children: [
+										{
+											type: 'noddityTemplateVariable',
+											name: 'with',
+										},
+									],
+									file: 'big.md',
+								},
+								{
+									type: 'text',
+									value: ' template',
+								},
+							],
+							file: 'file.md',
+						},
+						{
+							type: 'text',
+							value: ' word2',
 						},
 					],
 				},


### PR DESCRIPTION
Added lots of tests, and improved parsing substantially.

Also, added support for Markdown and Noddity templates inside of Noddity link text, e.g. for this Noddity text:

```markdown
Link to my [[cars.md|document about cars ::icon.md|car|size=big::]] over here
```

The tree output would be:

```js
const tree = {
	type: 'root',
	children: [
		{
			type: 'paragraph',
			children: [
				{
					type: 'text',
					value: 'Link to my  ',
				},
				{
					type: 'noddityLink',
					file: 'cars.md',
					children: [
						{
							type: 'text',
							value: 'document about cars ',
						},
						{
							type: 'noddityTemplate',
							file: 'icon.md',
							children: [
								{
									type: 'noddityTemplateVariable',
									name: 'car',
								},
								{
									type: 'noddityTemplateVariable',
									name: 'size',
									value: 'big',
								},
							],
						},
					],
				},
				{
					type: 'text',
					value: ' over here',
				},
			],
		},
	],
}
```